### PR TITLE
Add a simple anonymous API to retrieve member org info

### DIFF
--- a/directory/api.py
+++ b/directory/api.py
@@ -1,0 +1,16 @@
+import json
+from django.shortcuts import get_object_or_404
+from django.http import HttpResponse
+
+from .models import Organization, City
+
+def members(request, city):
+    city = get_object_or_404(City, slug=city)
+    orgs = Organization.objects.filter(
+        is_active=True,
+        city=city
+    ).order_by('name')
+    return HttpResponse(json.dumps([{
+        "name": org.name,
+        "website": org.website
+    } for org in orgs]), content_type='application/json')

--- a/directory/tests/test_api.py
+++ b/directory/tests/test_api.py
@@ -1,0 +1,23 @@
+import json
+
+from django.test import TestCase
+
+class ApiTests(TestCase):
+    fixtures = ['wnyc.json', 'amnh.json']
+
+    def get_json(self, url):
+        response = self.client.get(url)
+        if response['Content-Type'] == 'application/json':
+            response.json = json.loads(response.content)
+        return response
+
+    def test_members(self):
+        response = self.get_json('/api/v1/cities/nyc/members')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, [
+            {"name": "American Museum of Natural History",
+             "website": "http://www.amnh.org/"},
+            {"name": "WNYC's Radio Rookies",
+             "website": "http://www.radiorookies.org/"},
+        ])

--- a/directory/urls.py
+++ b/directory/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 
 from .multi_city import viewname_prefix
-from . import views
+from . import views, api
 
 def city_scoped_directory_patterns(is_multi_city_site):
     prefix = viewname_prefix(is_multi_city_site)
@@ -28,6 +28,7 @@ urlpatterns = patterns('',
         views.user_detail, name='user_detail'),
 
     url(r'^accounts/profile/$', views.user_edit, name='user_edit'),
+    url(r'^api/v1/cities/(?P<city>[A-Za-z0-9_\-]+)/members$', api.members),
 )
 
 urlpatterns += city_scoped_directory_patterns(is_multi_city_site=False)


### PR DESCRIPTION
Hive NYC would like the [current member list](http://hivenyc.org/members/) on their Wordpress-based website to be pulled directly from the directory, so they don't have to maintain it in two separate places.

One way to support this is to add a simple API endpoint, e.g.:

```
GET /api/v1/cities/:city/members
```

This could return a JSON response such as:

``` json
[
            {"name": "American Museum of Natural History",
             "website": "http://www.amnh.org/"},
            {"name": "WNYC's Radio Rookies",
             "website": "http://www.radiorookies.org/"}
]
```

A simple [WordPress plugin](https://gist.github.com/toolness/b5416a7eb2d27dd4d263) or JS include on the Hive NYC site could then grab this JSON and drop it into a template.

Note that there is currently a JSON endpoint at `/find.json`, but this is a _private_ API, in that it's used by Ajax code on the directory search page, and uses the current user's session cookie for authentication. Everything under the `/api/` endpoint, in contrast, will be for external clients like the Hive NYC wordpress site. If and when we offer privileged data through this API, requests will probably be authenticated through OAuth or somesuch, as opposed to session cookie.
